### PR TITLE
code & layout improvements

### DIFF
--- a/components/Layout.jsx
+++ b/components/Layout.jsx
@@ -1,5 +1,5 @@
 import Head from "next/head"
-import Navbar from "./ui/Navbar"
+import Navbar from "@components/ui/Navbar"
 
 const Layout = ({ children }) => {
     return (

--- a/components/SectionWrapper.jsx
+++ b/components/SectionWrapper.jsx
@@ -1,5 +1,7 @@
+import { twMerge } from "tailwind-merge"
+
 const SectionWrapper = ({ children, ...props }) => (
-    <section {...props} className={`xl:py-20 py-20 ${props.className || ""}`}>
+    <section {...props} className={twMerge('xl:py-20 py-20', props.className)}>
         {children}
     </section>
 )

--- a/components/ui/FooterCTA/index.jsx
+++ b/components/ui/FooterCTA/index.jsx
@@ -8,10 +8,10 @@ import discordIcon from "@public/logos/discord.svg"
 
 const FooterCTA = () => (
     <SectionWrapper className="bg-[#F5F1EB] py-10">
-        <div class="flex max-w-screen-2xl mx-auto xl:px-[55px] px-8">
+        <div className="flex max-w-screen-2xl mx-auto xl:px-[55px] px-8">
             <div className="flex flex-col items-center flex-1 p-[60px] gap-[45px] rounded-[60px] border border-[#524B48]">
-                <h1 class="text-[#332B29] text-center font-bold text-[48px] leading-normal self-stretch">
-                    The Yield Venue for Shared <span className="bg-[#A1FD59] p-3">Security</span>
+                <h1 className="text-[#332B29] text-center font-bold text-[48px] leading-[48px] self-stretch">
+                    The Yield Venue for Shared <span className="bg-[#A1FD59] p-1 md:p-3">Security</span>
                 </h1>
                 <NavLink href="https://discord.gg/8aFPCXPwAd" target="_blank"
                     className="flex h-[127px] p-[10px] justify-center items-center gap-[10px] self-stretch xl:rounded-[100px] 

--- a/components/ui/FooterCTA/index.jsx
+++ b/components/ui/FooterCTA/index.jsx
@@ -11,7 +11,7 @@ const FooterCTA = () => (
         <div className="flex max-w-screen-2xl mx-auto xl:px-[55px] px-8">
             <div className="flex flex-col items-center flex-1 p-[60px] gap-[45px] rounded-[60px] border border-[#524B48]">
                 <h1 className="text-[#332B29] text-center font-bold text-[48px] leading-[48px] self-stretch">
-                    The Yield Venue for Shared <span className="bg-[#A1FD59] p-1 md:p-3">Security</span>
+                    The Yield Venue for Shared <span className="relative z-0 before:absolute before:content-[''] before:w-[100%] before:h-[92%] before:inset-y-6px before:z-[-1] before:bg-[#A1FD59]">Security</span>
                 </h1>
                 <NavLink href="https://discord.gg/8aFPCXPwAd" target="_blank"
                     className="flex h-[127px] p-[10px] justify-center items-center gap-[10px] self-stretch xl:rounded-[100px] 

--- a/components/ui/FooterCTA/index.jsx
+++ b/components/ui/FooterCTA/index.jsx
@@ -1,11 +1,10 @@
-import SectionWrapper from "../../SectionWrapper"
-import NavLink from "../NavLink"
+import SectionWrapper from "@components/SectionWrapper"
+import NavLink from "@components/ui/NavLink"
 import Image from "next/image"
-import xIcon from "../../../public/logos/x.svg"
-import telegramIcon from "../../../public/logos/telegram.svg"
-import discordIcon from "../../../public/logos/discord.svg"
 
-
+import xIcon from "@public/logos/x.svg"
+import telegramIcon from "@public/logos/telegram.svg"
+import discordIcon from "@public/logos/discord.svg"
 
 const FooterCTA = () => (
     <SectionWrapper className="bg-[#F5F1EB] py-10">

--- a/components/ui/Hero/index.jsx
+++ b/components/ui/Hero/index.jsx
@@ -9,7 +9,7 @@ const Hero = () => (
         <div className="text-gray-600 mt-28 flex flex-col max-w-screen-2xl mx-auto">
             <div className="text-center flex-col flex flex-1">
                 <div className="text-[#332B29] text-center font-bold text-[76px] xl:text-[96px] leading-none max-w-[990px] mx-auto">
-                    The yield layer for shared <span className="bg-[#A1FD59] inline-block leading-[0.8] pt-2">security.</span>
+                    The yield layer for shared <span className="relative z-[-1] before:absolute before:content-[''] before:w-[100%] before:h-[68%] before:inset-y-[16px] before:z-[-2] before:bg-[#A1FD59]">security.</span>
                 </div>
                 <div className="flex mt-20 z-0 w-full flex-1 flex-col md:flex-row md:items-stretch items-center">
                     <Image src="/construction.svg" width="470" height="478" alt="construction" />

--- a/components/ui/Hero/index.jsx
+++ b/components/ui/Hero/index.jsx
@@ -1,13 +1,12 @@
-import NavLink from "../NavLink"
+import NavLink from "@components/ui/NavLink"
 import Image from "next/image"
-import xIcon from "../../../public/logos/x.svg"
-import telegramIcon from "../../../public/logos/telegram.svg"
-import discordIcon from "../../../public/logos/discord.svg"
-
+import xIcon from "@public/logos/x.svg"
+import telegramIcon from "@public/logos/telegram.svg"
+import discordIcon from "@public/logos/discord.svg"
 
 const Hero = () => (
     <section>
-        <div className="text-gray-600 mt-28 flex flex-col max-w-screen-2xl mx-auto" id="about">
+        <div className="text-gray-600 mt-28 flex flex-col max-w-screen-2xl mx-auto">
             <div className="text-center flex-col flex flex-1">
                 <div className="text-[#332B29] text-center font-bold text-[76px] xl:text-[96px] leading-none max-w-[990px] mx-auto">
                     The yield layer for shared <span className="bg-[#A1FD59]">security.</span>

--- a/components/ui/Hero/index.jsx
+++ b/components/ui/Hero/index.jsx
@@ -9,13 +9,13 @@ const Hero = () => (
         <div className="text-gray-600 mt-28 flex flex-col max-w-screen-2xl mx-auto">
             <div className="text-center flex-col flex flex-1">
                 <div className="text-[#332B29] text-center font-bold text-[76px] xl:text-[96px] leading-none max-w-[990px] mx-auto">
-                    The yield layer for shared <span className="bg-[#A1FD59]">security.</span>
+                    The yield layer for shared <span className="bg-[#A1FD59] inline-block leading-[0.8] pt-2">security.</span>
                 </div>
                 <div className="flex mt-20 z-0 w-full flex-1 flex-col md:flex-row md:items-stretch items-center">
                     <Image src="/construction.svg" width="470" height="478" alt="construction" />
                     <div className="xl:ml-7 flex flex-col xl:mt-10 sm:px-2 flex-1 px-4 xl:px-0 justify-between h-auto">
                         <div className="text__color--main text-[24px] text-left font-normal">
-                            Launch liquidity for shared security <br /> protocols. <br /> Native yield-streaming for the lowest cost <br /> of security.
+                            Launch liquidity for shared security protocols. <br /> Native yield-streaming for the lowest cost of security.
                         </div>
                         <div className="mt-10 flex flex-col">
                             <NavLink href="https://discord.gg/8aFPCXPwAd" target="_blank" className="flex w-[241px] h-[58px] 

--- a/components/ui/Navbar/index.jsx
+++ b/components/ui/Navbar/index.jsx
@@ -1,8 +1,9 @@
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
-import Brand from '../Brand'
-import NavLink from '../NavLink'
+import Brand from "@components/ui/Brand"
+import NavLink from "@components/ui/NavLink"
+import { twJoin } from 'tailwind-merge'
 
 const Navbar = () => {
     const [scrolled, setScrolled] = useState(false);
@@ -29,7 +30,7 @@ const Navbar = () => {
     }, []);
     
     const navigation = [
-        { title: "ABOUT", path: "#about" },
+        { title: "ABOUT", path: "#" },
         { title: "SOLUTION", path: "#solution" },
         { title: "COMPONENTS", path: "#components" },
     ]
@@ -51,7 +52,7 @@ const Navbar = () => {
 
     return (
         <header className='fixed top-0 w-full z-40'>
-            <nav className={`w-full md:static md:text-sm flex ${state ? "fixed z-10 h-full" : ""} ${scrolled ? 'md:bg-[#F5F1EB] bg-transparent' : ''}`}>
+            <nav className={twJoin("w-full md:static md:text-sm flex", state && "fixed z-10 h-full", scrolled && "md:bg-[#F5F1EB] bg-transparent")}>
                 <div className="md:custom-screen md:mx-auto gap-2 md:py-5 md:flex flex w-full md:w-auto items-end md:items-center flex-col md:flex-row lg:w-[990px]">
                     <div className={`custom-screen items-center mx-auto p-4 md:p-0 flex justify-between w-full ${scrolled ? 'bg-[#F5F1EB] md:bg-transparent' : ''}`}>
                         <Brand />
@@ -78,7 +79,7 @@ const Navbar = () => {
                             border border-[#003944] rounded-lg md:bg-transparent bg-[#72BACA] md:border-none md:text-gray-700">
                             {navigation.map((item, idx) => {
                                 return (
-                                    <li key={`li-${idx}`}>
+                                    <li key={idx}>
                                         <Link href={item.path} key={idx} className="duration-150 hover:text-[#F5F1EB] hover:bg-[#332b29c9] h-10 px-5 py-2.5 md:rounded-[40px] md:border md:border-[#514a47] 
                                             justify-center items-center gap-2.5 inline-flex text-center font-medium text-[16px] leading-normal uppercase text-[#332B29]">
                                             {item.title}

--- a/components/ui/Testimonials/index.jsx
+++ b/components/ui/Testimonials/index.jsx
@@ -1,4 +1,4 @@
-import SectionWrapper from "../../SectionWrapper"
+import SectionWrapper from "@components/SectionWrapper"
 
 const Testimonials = () => {
 
@@ -26,9 +26,9 @@ const Testimonials = () => {
     ]
 
     return (
-        <SectionWrapper className="pb-0 xl:pb-0">
+        <SectionWrapper className="pb-0 xl:pb-0" id="components">
             <div className="flex flex-col justify-center">
-                <div id="components" className="w-full bg-[#72BACA] xl:rounded-[60px] rounded-3xl z-10
+                <div className="w-full bg-[#72BACA] xl:rounded-[60px] rounded-3xl z-10
                     xl:py-16 py-8 xl:px-24 px-8 max-w-screen-2xl flex-1 mx-auto">
                 <div className="text-[#003944] xl:text-[64px] text-[42px] xl:text-start text-center font-bold uppercase flex-1">key components</div>
                     <ul>

--- a/components/ui/ToolKit/index.jsx
+++ b/components/ui/ToolKit/index.jsx
@@ -1,8 +1,8 @@
-import SectionWrapper from "../../SectionWrapper"
+import SectionWrapper from "@components/SectionWrapper"
 import Image from "next/image"
-import staking from "../../../public/icons/staking.svg"
-import calculation from "../../../public/icons/calculation.svg"
-import distribution from "../../../public/icons/distribution.svg"
+import staking from "@public/icons/staking.svg"
+import calculation from "@public/icons/calculation.svg"
+import distribution from "@public/icons/distribution.svg"
 
 const ToolKit = () => {
 
@@ -25,8 +25,8 @@ const ToolKit = () => {
     ]
 
     return (
-        <SectionWrapper>
-            <div id="solution" className="max-w-screen-xl mx-auto px-4 md:px-8">
+        <SectionWrapper id="solution">
+            <div className="max-w-screen-xl mx-auto px-4 md:px-8">
                 <div className="max-w-2xl space-y-3 text-center xl:text-left text-xl font-medium uppercase mt-10">
                     How does yieldi work?
                 </div>

--- a/components/ui/ToolKit/index.jsx
+++ b/components/ui/ToolKit/index.jsx
@@ -50,7 +50,7 @@ const ToolKit = () => {
                         ))}
                     </ul>
                 </div>
-                <div className="text-[64px] font-bold xl:mt-32 mt-8 pt-2 text-center xl:leading-[64px] leading-[60px]">What Problem Does Yieldi Solve?</div>
+                <div className="text-[64px] font-bold xl:mt-32 mt-8 pt-2 text-start xl:leading-[64px] leading-[60px]">What Problem Does Yieldi Solve?</div>
                 <div className="flex xl:flex-row flex-col justify-between items-center xl:mt-[110px] mt-9">
                     <div className="xl:mr-20 mr-0">
                         <span className="text-2xl font-bold">

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["components/*"],
+      "@utils/*": ["utils/*"],
+      "@styles/*": ["styles/*"],
+      "@public/*": ["public/*"],
+    }
+  },
+  "include": ["**/*.js", "**/*.jsx"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "eslint-config-next": "13.1.1",
     "next": "14.2.5",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "tailwind-merge": "^2.5.2"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.3",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,5 @@
-import Layout from "../components/Layout";
-import "../styles/globals.css";
+import Layout from "@components/Layout";
+import "@styles/globals.css";
 
 export default function App({ Component, pageProps }) {
   return (

--- a/pages/get-started.js
+++ b/pages/get-started.js
@@ -1,7 +1,7 @@
 import Head from "next/head";
-import Input from "../components/ui/Input";
-import Button from "../components/ui/Button";
-import Checkbox from "../components/ui/Checkbox";
+import Input from "@components/ui/Input";
+import Button from "@components/ui/Button";
+import Checkbox from "@components/ui/Checkbox";
 
 export default function GetStarted() {
   const servicesItems = [

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,9 +1,9 @@
 import Head from "next/head";
-import GradientWrapper from "../components/GradientWrapper";
-import FooterCTA from "../components/ui/FooterCTA";
-import Hero from "../components/ui/Hero";
-import Testimonials from "../components/ui/Testimonials";
-import ToolKit from "../components/ui/ToolKit";
+import GradientWrapper from "@components/GradientWrapper"
+import FooterCTA from "@components/ui/FooterCTA";
+import Hero from "@components/ui/Hero";
+import Testimonials from "@components/ui/Testimonials";
+import ToolKit from "@components/ui/ToolKit";
 
 export default function Home() {
   return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   react-dom:
     specifier: 18.2.0
     version: 18.2.0(react@18.2.0)
+  tailwind-merge:
+    specifier: ^2.5.2
+    version: 2.5.2
 
 devDependencies:
   '@tailwindcss/forms':
@@ -2111,6 +2114,10 @@ packages:
     dependencies:
       '@pkgr/utils': 2.3.1
       tslib: 2.4.1
+    dev: false
+
+  /tailwind-merge@2.5.2:
+    resolution: {integrity: sha512-kjEBm+pvD+6eAwzJL2Bi+02/9LFLal1Gs61+QB7HvTfQQ0aXwC5LGT8PEt1gS0CWKktKe6ysPTAy3cBC5MeiIg==}
     dev: false
 
   /tailwindcss@3.2.4(postcss@8.4.20):

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  mode: 'jit',
   content: [
     "./pages/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
- Use tailwind-merge instead of interpolating class values
- Set basepath in jsconfig to avoid relative pathing imports
- Set id on outermost section tags so that navigating via URI fragments don't get cut off
- Remove interpolated key values. Just use idx